### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   hytale-server-manager:
     image: ghcr.io/nebula-codes/hytale-server-manager:latest


### PR DESCRIPTION
Removed version as it is obsolete and is no longer needed.

htyale@HytalePanel:~$ docker compose up
WARN[0000] /home/hytale/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion