### PR TITLE
fix: consolidate PrismaClient into single shared singleton and fix HT…

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import { PrismaClient } from '@prisma/client';
+import sharedPrisma from './lib/prisma';
 import { Server as HTTPServer, createServer as createHTTPServer } from 'http';
 import { Server as HTTPSServer, createServer as createHTTPSServer } from 'https';
 import { Server as SocketServer } from 'socket.io';
@@ -118,7 +119,7 @@ export class App {
       pingTimeout: config.wsPingTimeout,
     });
 
-    this.prisma = new PrismaClient();
+    this.prisma = sharedPrisma;
 
     // Initialize permission and settings services
     this.permissionService = new PermissionService(this.prisma);

--- a/packages/server/src/lib/prisma.ts
+++ b/packages/server/src/lib/prisma.ts
@@ -1,0 +1,11 @@
+import { PrismaClient } from '@prisma/client';
+
+/**
+ * Shared PrismaClient singleton.
+ * Import this instead of creating a new PrismaClient() in each file.
+ * Having a single instance avoids SQLite "database is locked" errors
+ * that occur when multiple connection pools try to write concurrently.
+ */
+const prisma = new PrismaClient();
+
+export default prisma;

--- a/packages/server/src/middleware/auth.ts
+++ b/packages/server/src/middleware/auth.ts
@@ -1,11 +1,10 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
-import { PrismaClient } from '@prisma/client';
+import prisma from '../lib/prisma';
 import logger from '../utils/logger';
 import { PermissionCode } from '../permissions/definitions';
 import type { PermissionService } from '../services/PermissionService';
 
-const prisma = new PrismaClient();
 
 // JWT secret - must be set via environment variable (validated in auth routes on startup)
 const JWT_SECRET = process.env.JWT_SECRET || '';

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from 'express';
-import { PrismaClient } from '@prisma/client';
+import prisma from '../lib/prisma';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import logger from '../utils/logger';
@@ -8,7 +8,6 @@ import { ACTIVITY_ACTIONS, RESOURCE_TYPES } from '../constants/ActivityLogAction
 import { getActivityContext } from '../middleware/activityLogger';
 import { strictLimiter } from '../middleware/rateLimiter';
 
-const prisma = new PrismaClient();
 
 // JWT configuration - REQUIRE secrets from environment
 function getRequiredEnvVar(name: string): string {
@@ -33,16 +32,23 @@ const MAX_FAILED_ATTEMPTS = 5;
 const LOCKOUT_DURATION_MS = 15 * 60 * 1000; // 15 minutes
 
 // Cookie settings
-// secure: true in production by default (requires HTTPS)
-// Set INSECURE_COOKIES=true to allow HTTP (not recommended, only for local network testing)
+// secure: true only when the actual request arrived over HTTPS.
+// This prevents the UnRAID/HTTP loop where the browser silently drops Secure cookies
+// served over plain HTTP, causing every API call to fail with 401.
 const isProduction = process.env.NODE_ENV === 'production';
 const allowInsecureCookies = process.env.INSECURE_COOKIES === 'true';
-const COOKIE_OPTIONS = {
-  httpOnly: true,
-  secure: isProduction && !allowInsecureCookies,
-  sameSite: 'lax' as const,
-  path: '/',
-};
+
+function getCookieOptions(req: Request) {
+  // req.secure is true for direct HTTPS; x-forwarded-proto covers reverse-proxy setups.
+  const isSecureConnection = (req as any).secure ||
+    (req as any).headers?.['x-forwarded-proto'] === 'https';
+  return {
+    httpOnly: true,
+    secure: isProduction && !allowInsecureCookies && isSecureConnection,
+    sameSite: 'lax' as const,
+    path: '/',
+  };
+}
 
 const ACCESS_TOKEN_COOKIE = 'access_token';
 const REFRESH_TOKEN_COOKIE = 'refresh_token';
@@ -446,11 +452,11 @@ export function createAuthRoutes(): Router {
 
       // Set httpOnly cookies
       res.cookie(ACCESS_TOKEN_COOKIE, accessToken, {
-        ...COOKIE_OPTIONS,
+        ...getCookieOptions(req),
         maxAge: expiresIn * 1000,
       });
       res.cookie(REFRESH_TOKEN_COOKIE, refreshToken, {
-        ...COOKIE_OPTIONS,
+        ...getCookieOptions(req),
         maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
       });
 
@@ -531,11 +537,11 @@ export function createAuthRoutes(): Router {
       // Set new cookies
       const expiresIn = 60 * 60; // 1 hour
       res.cookie(ACCESS_TOKEN_COOKIE, newAccessToken, {
-        ...COOKIE_OPTIONS,
+        ...getCookieOptions(req),
         maxAge: expiresIn * 1000,
       });
       res.cookie(REFRESH_TOKEN_COOKIE, newRefreshToken, {
-        ...COOKIE_OPTIONS,
+        ...getCookieOptions(req),
         maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
       });
 

--- a/packages/server/src/routes/dashboard.ts
+++ b/packages/server/src/routes/dashboard.ts
@@ -1,5 +1,5 @@
 import { Router, Response } from 'express';
-import { PrismaClient } from '@prisma/client';
+import prisma from '../lib/prisma';
 import os from 'os';
 import { AuthenticatedRequest, requirePermission } from '../middleware/auth';
 import { MetricsService } from '../services/MetricsService';
@@ -7,7 +7,6 @@ import { AlertsService } from '../services/AlertsService';
 import { PERMISSIONS } from '../permissions/definitions';
 import logger from '../utils/logger';
 
-const prisma = new PrismaClient();
 
 // Store previous CPU measurement for delta calculation
 let previousCpuTimes: { idle: number; total: number } | null = null;

--- a/packages/server/src/routes/users.ts
+++ b/packages/server/src/routes/users.ts
@@ -1,10 +1,9 @@
 import { Router, Response } from 'express';
-import { PrismaClient } from '@prisma/client';
+import prisma from '../lib/prisma';
 import bcrypt from 'bcryptjs';
 import logger from '../utils/logger';
 import { AuthenticatedRequest, authorize } from '../middleware/auth';
 
-const prisma = new PrismaClient();
 
 /**
  * Create user management routes

--- a/packages/server/src/services/AlertsService.ts
+++ b/packages/server/src/services/AlertsService.ts
@@ -1,8 +1,7 @@
-import { PrismaClient } from '@prisma/client';
+import prisma from '../lib/prisma';
 import logger from '../utils/logger';
 import { DiscordNotificationService } from './DiscordNotificationService';
 
-const prisma = new PrismaClient();
 
 export type AlertType = 'server_down' | 'high_cpu' | 'high_memory' | 'high_disk' | 'player_join' | 'player_leave' | 'custom';
 export type AlertSeverity = 'info' | 'warning' | 'critical';

--- a/packages/server/src/services/AutomationRulesService.ts
+++ b/packages/server/src/services/AutomationRulesService.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import prisma from '../lib/prisma';
 import cron from 'node-cron';
 import logger from '../utils/logger';
 import { ServerService } from './ServerService';
@@ -6,7 +6,6 @@ import { BackupService } from './BackupService';
 import { ActivityLogService } from './ActivityLogService';
 import { ACTIVITY_ACTIONS, RESOURCE_TYPES } from '../constants/ActivityLogActions';
 
-const prisma = new PrismaClient();
 
 export type TriggerType = 'scheduled' | 'event' | 'condition';
 export type EventType = 'server_start' | 'server_stop' | 'player_join' | 'player_leave' | 'high_cpu' | 'high_memory';

--- a/packages/server/src/services/BackupService.ts
+++ b/packages/server/src/services/BackupService.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import prisma from '../lib/prisma';
 import archiver from 'archiver';
 import fs from 'fs-extra';
 import * as fsNative from 'fs';
@@ -10,7 +10,6 @@ import { FtpStorageService } from './FtpStorageService';
 import config from '../config';
 import logger from '../utils/logger';
 
-const prisma = new PrismaClient();
 
 // Error codes for locked/busy files
 const LOCKED_FILE_ERRORS = ['EBUSY', 'EACCES', 'EPERM', 'ETXTBSY'];

--- a/packages/server/src/services/FileService.ts
+++ b/packages/server/src/services/FileService.ts
@@ -1,10 +1,9 @@
-import { PrismaClient } from '@prisma/client';
+import prisma from '../lib/prisma';
 import fs from 'fs-extra';
 import path from 'path';
 import unzipper from 'unzipper';
 import logger from '../utils/logger';
 
-const prisma = new PrismaClient();
 
 export interface FileInfo {
   name: string;

--- a/packages/server/src/services/HytaleDownloaderService.ts
+++ b/packages/server/src/services/HytaleDownloaderService.ts
@@ -3,12 +3,11 @@ import fs from 'fs-extra';
 import axios from 'axios';
 import { spawn, ChildProcess } from 'child_process';
 import { EventEmitter } from 'events';
-import { PrismaClient } from '@prisma/client';
+import prisma from '../lib/prisma';
 import unzipper from 'unzipper';
 import { getBasePath_ } from '../config';
 import logger from '../utils/logger';
 
-const prisma = new PrismaClient();
 
 // ==========================================
 // Types

--- a/packages/server/src/services/MetricsService.ts
+++ b/packages/server/src/services/MetricsService.ts
@@ -1,10 +1,9 @@
-import { PrismaClient } from '@prisma/client';
+import prisma from '../lib/prisma';
 import os from 'os';
 import fs from 'fs-extra';
 import path from 'path';
 import logger from '../utils/logger';
 
-const prisma = new PrismaClient();
 
 export interface MetricData {
   timestamp: Date;

--- a/packages/server/src/services/SchedulerService.ts
+++ b/packages/server/src/services/SchedulerService.ts
@@ -1,11 +1,10 @@
-import { PrismaClient } from '@prisma/client';
+import prisma from '../lib/prisma';
 import cron from 'node-cron';
 import { ServerService } from './ServerService';
 import { BackupService } from './BackupService';
 import { ConsoleService } from './ConsoleService';
 import logger from '../utils/logger';
 
-const prisma = new PrismaClient();
 
 export class SchedulerService {
   private tasks: Map<string, cron.ScheduledTask> = new Map();

--- a/packages/server/src/services/ServerUpdateService.ts
+++ b/packages/server/src/services/ServerUpdateService.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events';
 import { PrismaClient } from '@prisma/client';
+import prisma from '../lib/prisma';
 import fs from 'fs-extra';
 import path from 'path';
 import { hytaleDownloaderService } from './HytaleDownloaderService';
@@ -100,7 +101,7 @@ class ServerUpdateService extends EventEmitter {
 
   constructor() {
     super();
-    this.prisma = new PrismaClient();
+    this.prisma = prisma;
   }
 
   /**

--- a/packages/server/src/services/WorldsService.ts
+++ b/packages/server/src/services/WorldsService.ts
@@ -1,11 +1,10 @@
-import { PrismaClient } from '@prisma/client';
+import prisma from '../lib/prisma';
 import fs from 'fs-extra';
 import path from 'path';
 import archiver from 'archiver';
 import unzipper from 'unzipper';
 import logger from '../utils/logger';
 
-const prisma = new PrismaClient();
 
 /**
  * Hytale World Config.json structure

--- a/packages/server/src/websocket/ConsoleEvents.ts
+++ b/packages/server/src/websocket/ConsoleEvents.ts
@@ -1,12 +1,11 @@
 import { Server as SocketServer, Socket } from 'socket.io';
 import jwt from 'jsonwebtoken';
-import { PrismaClient } from '@prisma/client';
+import prisma from '../lib/prisma';
 import { ServerService } from '../services/ServerService';
 import { ConsoleService } from '../services/ConsoleService';
 import logger from '../utils/logger';
 import { LogEntry } from '../types';
 
-const prisma = new PrismaClient();
 
 // Read JWT_SECRET lazily to ensure dotenv has loaded
 function getJwtSecret(): string {

--- a/packages/server/src/websocket/HytaleDownloaderEvents.ts
+++ b/packages/server/src/websocket/HytaleDownloaderEvents.ts
@@ -1,10 +1,9 @@
 import { Server as SocketServer, Socket } from 'socket.io';
 import jwt from 'jsonwebtoken';
-import { PrismaClient } from '@prisma/client';
+import prisma from '../lib/prisma';
 import { hytaleDownloaderService } from '../services/HytaleDownloaderService';
 import logger from '../utils/logger';
 
-const prisma = new PrismaClient();
 
 // Read JWT_SECRET lazily to ensure dotenv has loaded
 function getJwtSecret(): string {

--- a/packages/server/src/websocket/ServerEvents.ts
+++ b/packages/server/src/websocket/ServerEvents.ts
@@ -1,11 +1,10 @@
 import { Server as SocketServer, Socket } from 'socket.io';
 import jwt from 'jsonwebtoken';
-import { PrismaClient } from '@prisma/client';
+import prisma from '../lib/prisma';
 import { ServerService } from '../services/ServerService';
 import { ConsoleService } from '../services/ConsoleService';
 import logger from '../utils/logger';
 
-const prisma = new PrismaClient();
 
 // Read JWT_SECRET lazily to ensure dotenv has loaded
 function getJwtSecret(): string {

--- a/packages/server/src/websocket/ServerUpdateEvents.ts
+++ b/packages/server/src/websocket/ServerUpdateEvents.ts
@@ -1,10 +1,9 @@
 import { Server as SocketServer, Socket } from 'socket.io';
 import jwt from 'jsonwebtoken';
-import { PrismaClient } from '@prisma/client';
+import prisma from '../lib/prisma';
 import { serverUpdateService } from '../services/ServerUpdateService';
 import logger from '../utils/logger';
 
-const prisma = new PrismaClient();
 
 // Read JWT_SECRET lazily to ensure dotenv has loaded
 function getJwtSecret(): string {


### PR DESCRIPTION
…TP cookie loop

**Shared PrismaClient (fixes SQLite locking and connection leak)**
- Added `src/lib/prisma.ts` exporting a single PrismaClient instance
- Replaced 18 separate `new PrismaClient()` calls across services, routes, middleware, and websocket handlers with the shared singleton
- Affected files: FileService, BackupService, MetricsService, AlertsService, AutomationRulesService, WorldsService, HytaleDownloaderService, SchedulerService, ServerUpdateService, ConsoleEvents, ServerEvents, HytaleDownloaderEvents, ServerUpdateEvents, routes/auth, routes/dashboard, routes/users, middleware/auth, app.ts
- SQLite serialises writes per connection pool; multiple pools caused intermittent "database is locked" errors and wasted idle connections

**Dynamic cookie secure flag (fixes session-expired loop on UnRAID/HTTP)**
- Replaced static `COOKIE_OPTIONS` with `getCookieOptions(req)` in auth routes
- `secure` is now set only when the actual request arrived over HTTPS (`req.secure` or `x-forwarded-proto: https`), not based solely on NODE_ENV
- Previously in production the browser silently rejected `Secure` cookies served over plain HTTP, causing all API calls to fail with 401, the refresh endpoint to also fail (no cookie), and users to be immediately logged out in an infinite loop

https://claude.ai/code/session_01EAcnhHcCf2B3ABEyyTX1n8